### PR TITLE
Environment will come within provider scope

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,8 @@ service: lambda-kittens-app
 provider:
     name: aws
     runtime: nodejs12.x
+    environment:
+        DYNAMODB_KITTEN_TABLE: ${self:service}-kittens-${opt:stage}
 
 iamRoleStatements:
     - Effect: 'Allow'
@@ -14,8 +16,7 @@ iamRoleStatements:
           - dynamodb:DeleteItem
       Resource: arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/${self:service}-kittens-${opt:stage}
 
-environment:
-    DYNAMODB_KITTEN_TABLE: ${self:service}-kittens-${opt:stage}
+
 functions:
     create:
         handler: handler.createKitten


### PR DESCRIPTION
Environment outside the provider scope gives an error. Within the code it is not able to read the table name and returns undefined. I guess this is due to some update but anyways look into the link below for a detailed error description and answer.

https://stackoverflow.com/questions/68051340/unable-to-fetch-tablename-serverless-framework-missing-required-key-tablename/68057601?noredirect=1#comment120291527_68057601 for more detail.